### PR TITLE
Remove Extra Blank Lines

### DIFF
--- a/src/Barryvdh/Reflection/DocBlock/Serializer.php
+++ b/src/Barryvdh/Reflection/DocBlock/Serializer.php
@@ -207,7 +207,7 @@ class Serializer
         }
         $text = str_replace("\n", "\n{$indent} * ", $text);
 
-        $comment = "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n";
+        $comment = !empty($text)? "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n" : "{$firstIndent}/**\n";
 
         $tags = array_values($docblock->getTags());
 


### PR DESCRIPTION
Correcting an issue where there are two empty lines, first with an extra space, when there is no text to display on the first line.